### PR TITLE
Stat Calculator -- Split Table to current level and advancement requirements

### DIFF
--- a/src/routes/Pages/Calculators/Components/level-info.component.js
+++ b/src/routes/Pages/Calculators/Components/level-info.component.js
@@ -3,6 +3,7 @@ import CmtCardContent from '@coremat/CmtCard/CmtCardContent';
 import CmtCardHeader from '@coremat/CmtCard/CmtCardHeader';
 import { Box, Table, TableBody, TableCell, TableContainer, TableRow, Tooltip, Typography } from '@mui/material';
 import { intToString } from '../Helpers/calculator.helpers';
+import { alignProperty } from '@mui/material/styles/cssUtils';
 
 export default function LevelInfo(props) {
   const { level, advExp, maxExp } = props;
@@ -15,34 +16,66 @@ export default function LevelInfo(props) {
             <Table size="small">
               <TableBody>
                 <TableRow>
+                  <TableCell align="right">
+                    <Typography>
+                      <strong>Level {level} Requirements</strong>
+                    </Typography>
+                  </TableCell>
+                  <TableCell></TableCell>
+                  <TableCell align="right">
+                    <Typography>
+                      <strong>Level {level + 1} Requirements</strong>
+                    </Typography>
+                  </TableCell>
+                  <TableCell></TableCell>
+                </TableRow>
+
+                <TableRow>
                   <TableCell>
                     <Typography>Stat Requirement</Typography>
                   </TableCell>
                   <TableCell>
                     <Typography>{Math.max(0, (level - 7) * 10)}</Typography>
                   </TableCell>
+
+                  <TableCell>
+                    <Typography>Stat Requirement</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>{Math.max(0, (level - 6) * 10)}</Typography>
+                  </TableCell>
+                </TableRow>
+
+                <TableRow>
                   <TableCell>
                     <Typography>Skill Requirement</Typography>
                   </TableCell>
                   <TableCell>
                     <Typography>{14 * (level + 1)}</Typography>
                   </TableCell>
+                  <TableCell>
+                    <Typography>Skill Requirement</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>{14 * (level + 2)}</Typography>
+                  </TableCell>
                 </TableRow>
+
                 <TableRow>
-                  <TableCell>
-                    <Typography>Level Cost</Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Tooltip title={parseInt(advExp).toLocaleString('en-US')}>
-                      <Typography>{intToString(advExp, 2)}</Typography>
-                    </Tooltip>
-                  </TableCell>
                   <TableCell>
                     <Typography>Max Experience</Typography>
                   </TableCell>
                   <TableCell>
                     <Tooltip title={parseInt(maxExp).toLocaleString('en-US')}>
                       <Typography>{intToString(maxExp, 2)}</Typography>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>Level Cost</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Tooltip title={parseInt(advExp).toLocaleString('en-US')}>
+                      <Typography>{intToString(advExp, 2)}</Typography>
                     </Tooltip>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
I redid the Stats > Level Information table. It now includes a column for the "current" level requirements and a column for the "next" level requirements. This way it easily shows what's needed to advance without incrementing the level each time.